### PR TITLE
feat: content for two tabs

### DIFF
--- a/src/app/components/card-list/card-list.html
+++ b/src/app/components/card-list/card-list.html
@@ -1,5 +1,5 @@
 <div class="card-list">
-  @for (card of cards; track card.id) {
+  @for (card of cards(); track card.id) {
   <app-card [layoutClass]="layoutClass(card)" [card]="card"></app-card>
   }
 </div>

--- a/src/app/components/card-list/card-list.ts
+++ b/src/app/components/card-list/card-list.ts
@@ -1,17 +1,16 @@
-import { Component } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { Card } from './card/card';
 import { CardModel } from '../../../models/types';
-import { DASHBOARD_MOCK } from '../../../mock-data/dashboard.mock';
 
 @Component({
   selector: 'app-card-list',
+  standalone: true,
   imports: [Card],
   templateUrl: './card-list.html',
   styleUrl: './card-list.scss',
 })
 export class CardList {
-  protected readonly cards: CardModel[] =
-    DASHBOARD_MOCK.tabs.find((tab) => tab.id === 'overview')?.cards ?? [];
+  cards = input.required<CardModel[]>();
 
   layoutClass(card: CardModel): string {
     switch (card.layout) {

--- a/src/app/components/dashboard/dashboard.html
+++ b/src/app/components/dashboard/dashboard.html
@@ -1,6 +1,8 @@
-<mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start">
+<mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start" (selectedIndexChange)="onTabChange($event)">
   <mat-tab label="Overview">
-    <app-card-list></app-card-list>
+    <app-card-list [cards]="cards()"></app-card-list>
   </mat-tab>
-  <mat-tab label="Lights">Content 2</mat-tab>
+  <mat-tab label="Lights">
+    <app-card-list [cards]="cards()"></app-card-list>
+  </mat-tab>
 </mat-tab-group>

--- a/src/app/components/dashboard/dashboard.ts
+++ b/src/app/components/dashboard/dashboard.ts
@@ -1,6 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, computed, signal } from '@angular/core';
 import { MatTabsModule } from '@angular/material/tabs';
 import { CardList } from '../card-list/card-list';
+import { TabId } from '../../../models/types';
+import { DASHBOARD_MOCK } from '../../../mock-data/dashboard.mock';
 
 @Component({
   selector: 'app-dashboard',
@@ -8,4 +10,18 @@ import { CardList } from '../card-list/card-list';
   templateUrl: './dashboard.html',
   styleUrl: './dashboard.scss',
 })
-export class Dashboard {}
+export class Dashboard {
+  activeTabId = signal<TabId>('overview');
+
+  cards = computed(() => {
+    const tabId = this.activeTabId();
+    const tab = DASHBOARD_MOCK.tabs.find((t) => t.id === tabId);
+    return tab?.cards ?? [];
+  });
+
+  onTabChange(index: number) {
+    const tabId: TabId = index === 0 ? 'overview' : 'lights';
+
+    this.activeTabId.set(tabId);
+  }
+}


### PR DESCRIPTION
# 🚀 RS School — Smart Home UI Pull Request
- **Issue(s):** Closes #7

---

## 📝 Summary
Briefly describe what was implemented in this PR.

cards are shown by tabs





## 📸 Screenshots / Demo (optional)
<img width="1908" height="909" alt="image" src="https://github.com/user-attachments/assets/8599792c-7bc6-4f1b-82ea-ef9ae5d0a5fa" />
<img width="1912" height="909" alt="image" src="https://github.com/user-attachments/assets/18279315-8bc0-4286-b668-31f30c863a78" />

---
