### PR TITLE
Feature/delete dashboard

### DIFF
--- a/src/app/components/pages/dashboard-page/dashboard-page.html
+++ b/src/app/components/pages/dashboard-page/dashboard-page.html
@@ -18,6 +18,10 @@
           <mat-icon>edit</mat-icon>
           Edit
         </button>
+        <button mat-raised-button color="primary" (click)="deleteDashboard()">
+          <mat-icon>delete</mat-icon>
+          Delete
+        </button>
       </div>
       } @else {
       <div class="dashboard__controls">

--- a/src/app/components/pages/dashboard-page/dashboard-page.ts
+++ b/src/app/components/pages/dashboard-page/dashboard-page.ts
@@ -88,6 +88,6 @@ export class DashboardPage implements OnInit {
 
   deleteDashboard() {
     const dashboardId = this.route.snapshot.params['dashboardId'];
-    this.store.dispatch(DashboardActions.deleteDashboard(dashboardId));
+    this.store.dispatch(DashboardActions.deleteDashboard({ dashboardId }));
   }
 }

--- a/src/app/components/pages/dashboard-page/dashboard-page.ts
+++ b/src/app/components/pages/dashboard-page/dashboard-page.ts
@@ -85,4 +85,9 @@ export class DashboardPage implements OnInit {
   exitEditMode() {
     this.store.dispatch(DashboardActions.exitEditMode());
   }
+
+  deleteDashboard() {
+    const dashboardId = this.route.snapshot.params['dashboardId'];
+    this.store.dispatch(DashboardActions.deleteDashboard(dashboardId));
+  }
 }

--- a/src/app/components/sidebar/sidebar-menu/sidebar-menu.html
+++ b/src/app/components/sidebar/sidebar-menu/sidebar-menu.html
@@ -1,6 +1,6 @@
 <mat-nav-list class="sidebar-menu">
 
-  @if (isLoading) {
+  @if (isLoading()) {
   <div class="loading-state">
     <mat-spinner diameter="30"></mat-spinner>
     <p>Loading...</p>
@@ -14,14 +14,14 @@
   </div>
   }
 
-  @if (!isLoading && !error && dashboards.length === 0) {
+  @if (!isLoading() && !error && dashboards.length === 0) {
   <div class="empty-state">
     <p>You don't have any dashboards yet.</p>
     <p>They'll appear here as soon as you create them.</p>
   </div>
   }
 
-  @if (!isLoading && !error && dashboards.length > 0) {
+  @if (!isLoading() && !error && dashboards.length > 0) {
   <div class="dashboard-list">
     @for (dashboard of dashboards; track trackById($index, dashboard)) {
     <button class="dashboard-item" (click)="selectDashboard(dashboard.id)"

--- a/src/app/components/sidebar/sidebar-menu/sidebar-menu.html
+++ b/src/app/components/sidebar/sidebar-menu/sidebar-menu.html
@@ -25,7 +25,7 @@
   <div class="dashboard-list">
     @for (dashboard of dashboards; track trackById($index, dashboard)) {
     <button class="dashboard-item" (click)="selectDashboard(dashboard.id)"
-      [class.active]="dashboard.id === activeDashboardId" routerLinkActive="active">
+      [class.active]="isActiveDashboard(dashboard.id)">
       <mat-icon>{{ dashboard.icon }}</mat-icon>
       <span>{{ dashboard.title }}</span>
     </button>

--- a/src/app/components/sidebar/sidebar-menu/sidebar-menu.ts
+++ b/src/app/components/sidebar/sidebar-menu/sidebar-menu.ts
@@ -3,7 +3,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { Dashboard, DashboardService } from '../../../services/dashboard-service/dashboard-service';
 import { AuthStateService } from '../../../services/auth-service/auth-state-service';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Actions, ofType } from '@ngrx/effects';
 import * as DashboardActions from '../../../store/dashboard/dashboard.actions';
@@ -21,11 +21,11 @@ export class SidebarMenu {
   private router = inject(Router);
   private actions$ = inject(Actions);
   private cdr = inject(ChangeDetectorRef);
+  private route = inject(ActivatedRoute);
 
   dashboards: Dashboard[] = [];
   isLoading = false;
   error: string | null = null;
-  activeDashboardId: string | null = null;
 
   constructor() {
     this.authStateService.isAuthenticated$.subscribe((isAuth) => {
@@ -36,35 +36,40 @@ export class SidebarMenu {
       }
     });
 
-    this.actions$.pipe(ofType(DashboardActions.createDashboardSuccess)).subscribe(() => {
-      this.loadDashboards();
-      this.cdr.detectChanges();
-    });
+    this.actions$
+      .pipe(
+        ofType(DashboardActions.createDashboardSuccess, DashboardActions.deleteDashboardSuccess),
+      )
+      .subscribe(() => {
+        setTimeout(() => {
+          this.loadDashboards();
+        }, 0);
+      });
+  }
 
-    this.actions$.pipe(ofType(DashboardActions.deleteDashboardSuccess)).subscribe(() => {
-      this.loadDashboards();
-      this.cdr.detectChanges();
-    });
+  isActiveDashboard(dashboardId: string): boolean {
+    return this.router.url.includes(`/dashboard/${dashboardId}`);
   }
 
   loadDashboards() {
-    this.isLoading = true;
-    this.error = null;
+    setTimeout(() => {
+      this.isLoading = true;
+      this.error = null;
 
-    this.dashboardService.getDashboards().subscribe({
-      next: (dashboards) => {
-        this.dashboards = dashboards;
-        this.isLoading = false;
-      },
-      error: () => {
-        this.error = 'Error in loading dashboards';
-        this.isLoading = false;
-      },
-    });
+      this.dashboardService.getDashboards().subscribe({
+        next: (dashboards) => {
+          this.dashboards = dashboards;
+          this.isLoading = false;
+        },
+        error: () => {
+          this.error = 'Error in loading dashboards';
+          this.isLoading = false;
+        },
+      });
+    }, 0);
   }
 
   selectDashboard(dashboardId: string) {
-    this.activeDashboardId = dashboardId;
     this.dashboardService.getDashboardById(dashboardId).subscribe({
       next: (dashboard) => {
         const firstTab = dashboard.tabs[0];

--- a/src/app/components/sidebar/sidebar-menu/sidebar-menu.ts
+++ b/src/app/components/sidebar/sidebar-menu/sidebar-menu.ts
@@ -40,6 +40,11 @@ export class SidebarMenu {
       this.loadDashboards();
       this.cdr.detectChanges();
     });
+
+    this.actions$.pipe(ofType(DashboardActions.deleteDashboardSuccess)).subscribe(() => {
+      this.loadDashboards();
+      this.cdr.detectChanges();
+    });
   }
 
   loadDashboards() {

--- a/src/app/components/sidebar/sidebar-menu/sidebar-menu.ts
+++ b/src/app/components/sidebar/sidebar-menu/sidebar-menu.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, inject } from '@angular/core';
+import { ChangeDetectorRef, Component, inject, signal } from '@angular/core';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { Dashboard, DashboardService } from '../../../services/dashboard-service/dashboard-service';
@@ -24,7 +24,7 @@ export class SidebarMenu {
   private route = inject(ActivatedRoute);
 
   dashboards: Dashboard[] = [];
-  isLoading = false;
+  isLoading = signal(false);
   error: string | null = null;
 
   constructor() {
@@ -52,21 +52,19 @@ export class SidebarMenu {
   }
 
   loadDashboards() {
-    setTimeout(() => {
-      this.isLoading = true;
-      this.error = null;
+    this.isLoading.set(true);
+    this.error = null;
 
-      this.dashboardService.getDashboards().subscribe({
-        next: (dashboards) => {
-          this.dashboards = dashboards;
-          this.isLoading = false;
-        },
-        error: () => {
-          this.error = 'Error in loading dashboards';
-          this.isLoading = false;
-        },
-      });
-    }, 0);
+    this.dashboardService.getDashboards().subscribe({
+      next: (dashboards) => {
+        this.dashboards = dashboards;
+        this.isLoading.set(false);
+      },
+      error: () => {
+        this.error = 'Error in loading dashboards';
+        this.isLoading.set(false);
+      },
+    });
   }
 
   selectDashboard(dashboardId: string) {

--- a/src/app/services/dashboard-service/dashboard-service.ts
+++ b/src/app/services/dashboard-service/dashboard-service.ts
@@ -26,4 +26,8 @@ export class DashboardService {
   createDashboard(dashboard: Dashboard): Observable<Dashboard> {
     return this.http.post<Dashboard>('/dashboards', dashboard);
   }
+
+  deleteDashboard(id: string) {
+    return this.http.delete<Dashboard>(`/dashboards/${id}`);
+  }
 }

--- a/src/app/store/dashboard/dashboard.actions.ts
+++ b/src/app/store/dashboard/dashboard.actions.ts
@@ -46,3 +46,18 @@ export const createDashboardFailure = createAction(
   '[Dashboard] Create Dashboard Failure',
   props<{ error: string }>(),
 );
+
+export const deleteDashboard = createAction(
+  '[Dashboard] Delete Dashboard',
+  props<{ dashboardId: string }>(),
+);
+
+export const deleteDashboardSuccess = createAction(
+  '[Dashboard] Delete Dashboard Success',
+  props<{ dashboardId: string }>(),
+);
+
+export const deleteDashboardFailure = createAction(
+  '[Dashboard] Delete Dashboard Failure',
+  props<{ error: string }>(),
+);

--- a/src/app/store/dashboard/dashboard.effects.ts
+++ b/src/app/store/dashboard/dashboard.effects.ts
@@ -72,4 +72,23 @@ export class DashboardEffects {
       ),
     ),
   );
+
+  deleteDashboard$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(DashboardActions.deleteDashboard),
+      switchMap(({ dashboardId }) =>
+        this.dashboardService.deleteDashboard(dashboardId).pipe(
+          switchMap(() =>
+            of(
+              DashboardActions.deleteDashboardSuccess({ dashboardId }),
+              DashboardActions.loadDashboards(),
+            ),
+          ),
+          catchError((error) =>
+            of(DashboardActions.deleteDashboardFailure({ error: error.message })),
+          ),
+        ),
+      ),
+    ),
+  );
 }

--- a/src/app/store/dashboard/dashboard.effects.ts
+++ b/src/app/store/dashboard/dashboard.effects.ts
@@ -23,6 +23,29 @@ export class DashboardEffects {
     { dispatch: false },
   );
 
+  navigateAfterDelete$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(DashboardActions.deleteDashboardSuccess),
+        switchMap(() =>
+          this.dashboardService.getDashboards().pipe(
+            tap((dashboards) => {
+              if (dashboards.length > 0) {
+                const firstDashboard = dashboards[0];
+                this.dashboardService.getDashboardById(firstDashboard.id).subscribe((detail) => {
+                  const firstTab = detail.tabs[0];
+                  void this.router.navigate(['/dashboard', firstDashboard.id, firstTab.id]);
+                });
+              } else {
+                void this.router.navigate(['/']);
+              }
+            }),
+          ),
+        ),
+      ),
+    { dispatch: false },
+  );
+
   loadDashboard$ = createEffect(() =>
     this.actions$.pipe(
       ofType(DashboardActions.loadDashboard),


### PR DESCRIPTION
# 🚀 RS School — Smart Home UI Pull Request
- **Issue(s):** Closes #61 

---

## 📝 Summary
Briefly describe what was implemented in this PR.

- Add deleteDashboard action (dashboardId)
- Create effect that calls DELETE /api/dashboards/:id
- Show confirmation modal before deletion
- On success: reload dashboard list, navigate to first dashboard
- Delete button in toolbar (only visible when NOT in edit mode)
- refactor sidebar menu navigation




