### PR TITLE
Feature/save-dashboard

### DIFF
--- a/src/app/components/pages/dashboard-page/dashboard-page.html
+++ b/src/app/components/pages/dashboard-page/dashboard-page.html
@@ -30,7 +30,7 @@
           Discard
         </button>
 
-        <button mat-raised-button color="primary" (click)="exitEditMode()">
+        <button mat-raised-button color="primary" (click)="saveDashboard()">
           <mat-icon>save</mat-icon>
           Save
         </button>

--- a/src/app/components/pages/dashboard-page/dashboard-page.ts
+++ b/src/app/components/pages/dashboard-page/dashboard-page.ts
@@ -90,4 +90,9 @@ export class DashboardPage implements OnInit {
     const dashboardId = this.route.snapshot.params['dashboardId'];
     this.store.dispatch(DashboardActions.deleteDashboard({ dashboardId }));
   }
+
+  saveDashboard() {
+    const dashboardId = this.route.snapshot.params['dashboardId'];
+    this.store.dispatch(DashboardActions.saveDashboard({ dashboardId }));
+  }
 }

--- a/src/app/services/dashboard-service/dashboard-service.ts
+++ b/src/app/services/dashboard-service/dashboard-service.ts
@@ -30,4 +30,8 @@ export class DashboardService {
   deleteDashboard(id: string) {
     return this.http.delete<Dashboard>(`/dashboards/${id}`);
   }
+
+  updateDashboard(id: string, dashboard: Dashboard): Observable<DashboardData> {
+    return this.http.put<DashboardData>(`/dashboards/${id}`, dashboard);
+  }
 }

--- a/src/app/services/dashboard-service/dashboard-service.ts
+++ b/src/app/services/dashboard-service/dashboard-service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { DashboardData } from '../../../models/types';
+import { DashboardData, Tab } from '../../../models/types';
 
 export interface Dashboard {
   id: string;
@@ -31,7 +31,7 @@ export class DashboardService {
     return this.http.delete<Dashboard>(`/dashboards/${id}`);
   }
 
-  updateDashboard(id: string, dashboard: Dashboard): Observable<DashboardData> {
-    return this.http.put<DashboardData>(`/dashboards/${id}`, dashboard);
+  updateDashboard(id: string, data: { tabs: Tab[] }): Observable<DashboardData> {
+    return this.http.put<DashboardData>(`/dashboards/${id}`, data);
   }
 }

--- a/src/app/store/dashboard/dashboard.actions.ts
+++ b/src/app/store/dashboard/dashboard.actions.ts
@@ -62,6 +62,18 @@ export const deleteDashboardFailure = createAction(
   props<{ error: string }>(),
 );
 
+export const saveDashboard = createAction('[Dashboard] Save dashboard');
+
+export const saveDashboardSuccess = createAction(
+  '[Dashboard] Save dashboard success',
+  props<{ dashboard: DashboardData }>(),
+);
+
+export const saveDashboardFailure = createAction(
+  '[Dashboard] Save dashboard failure',
+  props<{ error: string }>(),
+);
+
 export const addTab = createAction('[Dashboard] Add Tab', props<{ title: string }>());
 
 export const removeTab = createAction('[Dashboard] Remove Tab', props<{ tabId: string }>());

--- a/src/app/store/dashboard/dashboard.actions.ts
+++ b/src/app/store/dashboard/dashboard.actions.ts
@@ -62,7 +62,10 @@ export const deleteDashboardFailure = createAction(
   props<{ error: string }>(),
 );
 
-export const saveDashboard = createAction('[Dashboard] Save dashboard');
+export const saveDashboard = createAction(
+  '[Dashboard] Save dashboard',
+  props<{ dashboardId: string }>(),
+);
 
 export const saveDashboardSuccess = createAction(
   '[Dashboard] Save dashboard success',

--- a/src/app/store/dashboard/dashboard.effects.ts
+++ b/src/app/store/dashboard/dashboard.effects.ts
@@ -2,15 +2,18 @@ import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { DashboardService } from '../../services/dashboard-service/dashboard-service';
 import * as DashboardActions from './dashboard.actions';
-import { catchError, switchMap, map, tap } from 'rxjs';
+import { catchError, switchMap, map, tap, withLatestFrom } from 'rxjs';
 import { of } from 'rxjs';
 import { Router } from '@angular/router';
+import { selectSelectedDashboard } from './dashboard.selectors';
+import { Store } from '@ngrx/store';
 
 @Injectable()
 export class DashboardEffects {
   private actions$ = inject(Actions);
   private dashboardService = inject(DashboardService);
   private router = inject(Router);
+  private store = inject(Store);
 
   navigateToCreatedDashboard$ = createEffect(
     () =>
@@ -93,6 +96,35 @@ export class DashboardEffects {
           ),
         ),
       ),
+    ),
+  );
+
+  saveDashboard$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(DashboardActions.saveDashboard),
+      withLatestFrom(this.store.select(selectSelectedDashboard)),
+      switchMap((result) => {
+        const action = result[0];
+        const dashboard = result[1];
+
+        if (!dashboard) {
+          return of(
+            DashboardActions.saveDashboardFailure({
+              error: 'No dashboard to save',
+            }),
+          );
+        }
+        const dashboardId = action.dashboardId;
+        const data = { tabs: dashboard.tabs };
+        return this.dashboardService.updateDashboard(dashboardId, data).pipe(
+          map((updatedDashboard) =>
+            DashboardActions.saveDashboardSuccess({ dashboard: updatedDashboard }),
+          ),
+          catchError((error) =>
+            of(DashboardActions.saveDashboardFailure({ error: error.message })),
+          ),
+        );
+      }),
     ),
   );
 

--- a/src/app/store/dashboard/dashboard.reducer.ts
+++ b/src/app/store/dashboard/dashboard.reducer.ts
@@ -114,4 +114,16 @@ export const dashboardReducer = createReducer(
       },
     };
   }),
+
+  on(DashboardActions.saveDashboardSuccess, (state, { dashboard }) => ({
+    ...state,
+    selectedDashboard: dashboard,
+    isEditMode: false,
+    originalSnapshot: null,
+  })),
+
+  on(DashboardActions.saveDashboardFailure, (state, { error }) => ({
+    ...state,
+    error,
+  })),
 );


### PR DESCRIPTION
# 🚀 RS School — Smart Home UI Pull Request
- **Issue(s):** Closes #63

---

## 📝 Summary
Briefly describe what was implemented in this PR.

Add saveDashboard action
Create effect that calls PUT /api/dashboards/:id with full dashboard structure
On success: exit edit mode, update store with saved data
Handle errors and show user feedback






